### PR TITLE
Highlight grocery items with notes

### DIFF
--- a/src/components/GroceryChecklist.tsx
+++ b/src/components/GroceryChecklist.tsx
@@ -14,7 +14,7 @@ import { SavedlistModal } from "./SavedlistModal";
 import { SpecialsModal } from "./SpecialsModal";
 import { QuantitySelector } from "./QuantitySelector";
 import { ItemDetailModal } from "./ItemDetailModal";
-import { parseSmartSyntax, normalizePlural, getIconForItem } from "@/lib/utils";
+import { parseSmartSyntax, normalizePlural, getIconForItem, cn } from "@/lib/utils";
 import { ItemIcon } from "./ItemIcon";
 
 interface GroceryItem {
@@ -80,6 +80,7 @@ function TouchSortableGroceryItem({
   const editQuantityRef = useRef<HTMLInputElement>(null);
   const nameInputRef = useRef<HTMLInputElement>(null);
   const { toast } = useToast();
+  const hasNotes = Boolean(item.notes?.trim());
 
   const handleQuantityEditToggle = () => {
     setIsQuantityEditing(prev => !prev);
@@ -200,15 +201,15 @@ function TouchSortableGroceryItem({
   }, [isDragging, dragStartY]);
 
   return (
-    <Card 
+    <Card
       ref={itemRef}
-      className={`py-2 px-0 shadow-card hover:shadow-elegant relative overflow-hidden ${
-        isDragging ? 'bg-green-50 border-green-200 shadow-lg' : ''
-      } ${
-        dragDestination !== null && dragDestination === index ? 'ring-2 ring-blue-500 ring-opacity-50' : ''
-      } ${
-        isQuantityEditing ? 'bg-green-50 border-green-200' : ''
-      }`}
+      className={cn(
+        "py-2 px-0 shadow-card hover:shadow-elegant relative overflow-hidden transition-colors",
+        hasNotes && !isDragging && !isQuantityEditing && "bg-accent/10 border-accent/30",
+        isDragging && "bg-green-50 border-green-200 shadow-lg",
+        dragDestination !== null && dragDestination === index && "ring-2 ring-blue-500 ring-opacity-50",
+        isQuantityEditing && "bg-green-50 border-green-200"
+      )}
       style={{
         transform: isDragging ? `translateY(${dragOffset}px) scale(1.02)` : 'none',
         zIndex: isDragging ? 1000 : 'auto',


### PR DESCRIPTION
## Summary
- tint grocery item cards with a light accent background whenever saved notes are present
- switch the card styling logic to use the shared `cn` helper for easier conditional class handling

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d0c3810590832aa1cedaced61117be